### PR TITLE
Make OpenMP Dynamic for Blender Linking

### DIFF
--- a/build_deps
+++ b/build_deps
@@ -96,7 +96,8 @@ if [[ $STAGE && $STAGE < $NEXT ]] ; then
   mkdir build && cd build
 
   echo " * Preparing OpenMP build"
-  if cmake -DLIBOMP_ENABLE_SHARED=OFF .. -DCMAKE_INSTALL_PREFIX=$TARGET ; then
+  if cmake -DLIBOMP_ENABLE_SHARED=ON \
+           -DCMAKE_INSTALL_PREFIX=$TARGET .. ; then
     echo " * OpenMP prepared successfully"
   else
     echo " !!! OpenMP cmake failed"


### PR DESCRIPTION
Prior to this commit the blender plugin would crash with a Trap because
two OpenMP libraries were being loaded. This commit fixes that by making
the library dynamic so that the plugin can be directed to the Blender
OpenMP library that's already been initialized.