### PR TITLE
Fix python numpy failed import and adjust compiler flags

### DIFF
--- a/build_deps
+++ b/build_deps
@@ -65,6 +65,8 @@ STAGE=$4
 PAUSE=5
 
 # platform specs
+export CFLAGS="-w -mmmx -mno-sse3 -mno-ssse3 -msse -msse2 -O2 -pipe -mfpmath=sse -fPIC"
+export CXXFLAGS="-std=c++11 ${CFLAGS}"
 export LDFLAGS="-L${TARGET}/lib"
 export MAKEOPTS="-j"$(( `sysctl -n hw.physicalcpu` ))
 export TMP="$WORK"
@@ -143,6 +145,8 @@ NEXT=1.2
 if [[ $STAGE && $STAGE < $NEXT ]] ; then
   begin_stage boost boost*.tar.gz
 
+  cp -vf $DIST/numpy_patch.cpp libs/python/src/numpy/numpy.cpp
+
   PYVER=`python3 --version 2>&1 | cut -d' ' -f2 | cut -d '.' -f'1 2'`
   echo " * Compiling boost for python-${PYVER}"
   PYROOT=`python3 -c "import sys; print(sys.prefix)"`
@@ -162,7 +166,7 @@ EOF
     echo " !!! Boost bootstrap failed"
     exit 1
   fi
-  if ./b2 $MAKEOPTS -aq \
+  if ./b2 $MAKEOPTS -aq cflags="$CFLAGS" cxxflags="$CXXFLAGS" \
     $CONFIGOPTS --prefix=$TARGET --layout=system --with-date_time --with-filesystem \
     --with-iostreams --with-locale --with-program_options --with-python --with-regex \
     --with-serialization --with-system --with-thread --with-chrono \

--- a/distfiles/numpy_patch.cpp
+++ b/distfiles/numpy_patch.cpp
@@ -1,0 +1,34 @@
+// Copyright Jim Bosch 2010-2012.
+// Copyright Stefan Seefeld 2016.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_PYTHON_NUMPY_INTERNAL_MAIN
+#include <boost/python/numpy/internal.hpp>
+#include <boost/python/numpy/dtype.hpp>
+
+namespace boost { namespace python { namespace numpy {
+
+#if PY_MAJOR_VERSION == 2
+static void wrap_import_array()
+{
+  import_array();
+}
+#else
+static void * wrap_import_array()
+{
+  import_array();
+  return NULL;
+}
+#endif
+
+void initialize(bool register_scalar_converters) 
+{
+  wrap_import_array();
+  import_ufunc();
+  if (register_scalar_converters)
+	dtype::register_scalar_converters();
+}
+
+}}} // namespace boost::python::numpy


### PR DESCRIPTION
Prior to this commit the compiler flags did not match the linux build
process and caused erroneous build errors. Also python3 would
intermittently fail to load numpy. This commit fixes that by updating
the compiler flags and adding a numpy patch to return null if python3
is used.